### PR TITLE
Fix Alphanumeric mode (slash was missing)

### DIFF
--- a/Codec/Binary/QRCode/Modes/Alphanumeric.hs
+++ b/Codec/Binary/QRCode/Modes/Alphanumeric.hs
@@ -7,7 +7,7 @@ import Codec.Binary.QRCode.Spec
 import Data.Char
 
 chars :: String
-chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-.:"
+chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:"
 
 table :: [(Char, Int)]
 table = zip chars [0..44]


### PR DESCRIPTION
The slash was missing and the code for the colon was wrong.